### PR TITLE
Feat/loan filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-popover": "^1.1.2",
+    "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-select':
+        specifier: ^2.1.2
+        version: 2.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.3.11)(react@18.3.1)
@@ -383,6 +386,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@radix-ui/number@1.1.0':
+    resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
 
   '@radix-ui/primitive@1.0.1':
     resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
@@ -745,6 +751,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-select@2.1.2':
+    resolution: {integrity: sha512-rZJtWmorC7dFRi0owDmoijm6nSJH1tVw64QGiNIZ9PNLyBDtG+iAq+XGsya052At4BfarzY/Dhv9wrrUr6IMZA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.0.2':
     resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
     peerDependencies:
@@ -835,6 +854,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-previous@1.1.0':
+    resolution: {integrity: sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-rect@1.1.0':
     resolution: {integrity: sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==}
     peerDependencies:
@@ -851,6 +879,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.1.0':
+    resolution: {integrity: sha512-N8MDZqtgCgG5S3aV60INAB475osJousYpZ4cTJ2cFbMpdHS5Y6loLTH8LPtkj2QN0x93J30HT/M3qJXM0+lyeQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/rect@1.1.0':
@@ -2234,6 +2275,8 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@radix-ui/number@1.1.0': {}
+
   '@radix-ui/primitive@1.0.1':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -2599,6 +2642,35 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-select@2.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.0
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.1(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.11)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.6.0(@types/react@18.3.11)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+      '@types/react-dom': 18.3.1
+
   '@radix-ui/react-slot@1.0.2(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -2670,6 +2742,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.11
 
+  '@radix-ui/react-use-previous@1.1.0(@types/react@18.3.11)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.11
+
   '@radix-ui/react-use-rect@1.1.0(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
       '@radix-ui/rect': 1.1.0
@@ -2683,6 +2761,15 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.11
+
+  '@radix-ui/react-visually-hidden@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+      '@types/react-dom': 18.3.1
 
   '@radix-ui/rect@1.1.0': {}
 

--- a/src/components/filterTables/filterFrequency.tsx
+++ b/src/components/filterTables/filterFrequency.tsx
@@ -1,79 +1,47 @@
-import { Check, ChevronsUpDown } from "lucide-react"
-
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { LoanFrequencyWithAll } from '@/hooks/use-loan-filters'
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command"
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
-import { useEffect, useState } from "react"
-import { formatFrequency } from "@/utils/format-frequency"
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select'
+import { frequencies, frequencyMap } from '@/utils/contants'
 
-interface IProps {
-  handleSetFrequency: (route: string) => void
+interface FilterFrequencyProps {
+  onChangeFrequency: (frequency: LoanFrequencyWithAll) => void
 }
 
-
-export function FilterFrequency({ handleSetFrequency }: IProps) {
-  const [open, setOpen] = useState(false)
-  const [value, setValue] = useState("")
-  const [frequencies] = useState<string[]>(['daily', 'weekly', 'biweekly', 'monthly', 'yearly'])
-
-  useEffect(() => {
-    handleSetFrequency(value)
-  }, [value])
-
+export function FilterFrequency({ onChangeFrequency }: FilterFrequencyProps) {
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className="w-[200px] justify-between"
-        >
-          {value
-            ? formatFrequency(frequencies.find((frequency) => frequency === value) || '' as any)
-            : "Filtrar tipo de prestamo..."}
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[300px] p-0">
-        <Command>
-          {/* <CommandInput placeholder="Buscar tipo de plan..." /> */}
-          <CommandList>
-            <CommandEmpty>Tipo de prestamo no encontrado</CommandEmpty>
-            <CommandGroup>
-              {frequencies.map((frequency) => (
-                <CommandItem
-                  key={frequency}
-                  value={frequency}
-                  onSelect={(currentValue) => {
-                    setValue(currentValue === value ? "" : currentValue)
-                    setOpen(false)
-                  }}
-                >
-                  <Check
-                    className={cn(
-                      "mr-2 h-4 w-4",
-                      value === frequency ? "opacity-100" : "opacity-0"
-                    )}
-                  />
-                  {formatFrequency(frequency as any)}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <Select
+      defaultValue="all"
+      onValueChange={(e) => onChangeFrequency(e as LoanFrequencyWithAll)}
+    >
+      <SelectTrigger className="min-w-[180px]">
+        <SelectValue placeholder="Tipo de préstamos" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>Frequencias</SelectLabel>
+          <SelectItem value="all" onClick={() => onChangeFrequency('all')}>
+            Todas las frequencias
+          </SelectItem>
+          {frequencies.map((frequency) => (
+            <SelectItem
+              key={frequency}
+              value={frequency}
+              onClick={() =>
+                onChangeFrequency(frequency as LoanFrequencyWithAll)
+              }
+            >
+              {frequencyMap[frequency]}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
   )
 }

--- a/src/components/filterTables/filterRoute.tsx
+++ b/src/components/filterTables/filterRoute.tsx
@@ -1,7 +1,7 @@
-import { Check, ChevronsUpDown } from "lucide-react"
+import { Check, ChevronsUpDown } from 'lucide-react'
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 import {
   Command,
   CommandEmpty,
@@ -9,24 +9,23 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
-} from "@/components/ui/command"
+} from '@/components/ui/command'
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@/components/ui/popover"
-import { useEffect, useState } from "react"
-import { IRoute } from "@/types/routes"
-import { getAllRoutes } from "@/services/route"
+} from '@/components/ui/popover'
+import { useEffect, useState } from 'react'
+import { IRoute } from '@/types/routes'
+import { getAllRoutes } from '@/services/route'
 
 interface IProps {
   handleSetRouteFilter: (route: string) => void
 }
 
-
 export function FilterRoute({ handleSetRouteFilter }: IProps) {
   const [open, setOpen] = useState(false)
-  const [value, setValue] = useState("")
+  const [value, setValue] = useState('')
   const [routes, setRoutes] = useState<IRoute[]>([])
 
   useEffect(() => {
@@ -34,12 +33,11 @@ export function FilterRoute({ handleSetRouteFilter }: IProps) {
   }, [value])
 
   useEffect(() => {
-    getAllRoutes()
-      .then((response) => {
-        if (response.success) {
-          setRoutes(response.data as any)
-        }
-      })
+    getAllRoutes().then((response) => {
+      if (response.success) {
+        setRoutes(response.data as any)
+      }
+    })
   }, [])
 
   return (
@@ -49,16 +47,18 @@ export function FilterRoute({ handleSetRouteFilter }: IProps) {
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className="w-full min-w-[200px] justify-between"
+          className="w-full min-w-[200px] font-normal justify-between"
         >
           {value
             ? routes.find((route) => route.name === value)?.name
-            : "Filtrar ruta..."}
+            : 'Filtrar ruta...'}
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-full
-       p-0">
+      <PopoverContent
+        className="w-full
+       p-0"
+      >
         <Command>
           <CommandInput placeholder="Buscar ruta..." />
           <CommandList>
@@ -69,14 +69,14 @@ export function FilterRoute({ handleSetRouteFilter }: IProps) {
                   key={route.name}
                   value={route.name}
                   onSelect={(currentValue) => {
-                    setValue(currentValue === value ? "" : currentValue)
+                    setValue(currentValue === value ? '' : currentValue)
                     setOpen(false)
                   }}
                 >
                   <Check
                     className={cn(
-                      "mr-2 h-4 w-4",
-                      value === route.name ? "opacity-100" : "opacity-0"
+                      'mr-2 h-4 w-4',
+                      value === route.name ? 'opacity-100' : 'opacity-0',
                     )}
                   />
                   {route.name}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,162 @@
+import * as React from "react"
+import {
+  CaretSortIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "@radix-ui/react-icons"
+import * as SelectPrimitive from "@radix-ui/react-select"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <CaretSortIcon className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUpIcon />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDownIcon />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <CheckIcon className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/src/hooks/use-loan-filters.ts
+++ b/src/hooks/use-loan-filters.ts
@@ -1,0 +1,56 @@
+import { ILoanTable } from '@/types/loans'
+import { useState } from 'react'
+
+export type LoanFrequency =
+  | 'daily'
+  | 'weekly'
+  | 'biweekly'
+  | 'monthly'
+  | 'yearly'
+
+export type LoanFilters = {
+  dni: string
+  frequency: LoanFrequency
+  route: string
+}
+
+export type LoanFrequencyWithAll = LoanFrequency | 'all'
+
+export function useLoanFilters({ loans }: { loans: ILoanTable[] }) {
+  const [dniQuery, setDniQuery] = useState('')
+  const [frequencyFilter, setFrequencyFilter] =
+    useState<LoanFrequencyWithAll>('all')
+  const [routeFilter, setRouteFilter] = useState('')
+
+  const filteredLoans = loans.filter((loan) => {
+    const dniMatch =
+      loan.dni.toLowerCase().includes(dniQuery.toLowerCase()) || dniQuery === ''
+    const frequencyMatch =
+      loan.frequency === frequencyFilter || frequencyFilter === 'all'
+    const routeMatch = loan.route === routeFilter || routeFilter === ''
+
+    return dniMatch && frequencyMatch && routeMatch
+  })
+
+  const searchByDni = (dni: string) => {
+    setDniQuery(dni)
+  }
+
+  const filterByFrequency = (frequency: LoanFrequencyWithAll) => {
+    setFrequencyFilter(frequency)
+  }
+
+  const filterByRoute = (route: string) => {
+    setRouteFilter(route)
+  }
+
+  return {
+    dniQuery,
+    frequencyFilter,
+    routeFilter,
+    filteredLoans,
+    searchByDni,
+    filterByFrequency,
+    filterByRoute,
+  }
+}

--- a/src/pages/loan/components/loans-table.tsx
+++ b/src/pages/loan/components/loans-table.tsx
@@ -1,0 +1,91 @@
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { ILoanTable } from '@/types/loans'
+import { formatFrequency } from '@/utils/format-frequency'
+import { formatLoanStatus } from '@/utils/format-loanState'
+import { formatPrice } from '@/utils/price-format'
+import { Actions } from './actions'
+
+export function LoansTable({ loans }: { loans: ILoanTable[] }) {
+  return (
+    <Table className="w-full">
+      <TableCaption>Lista de préstamos</TableCaption>
+      <TableHeader className="bg-gray-100">
+        <TableRow>
+          <TableHead className="text-gray-800 font-bold py-4 px-6">
+            Nombre del cliente
+          </TableHead>
+          <TableHead className="text-gray-800 font-bold py-4 px-6">
+            Cédula
+          </TableHead>
+          <TableHead className="text-gray-800 font-bold py-4 px-6">
+            Monto solicitado
+          </TableHead>
+          <TableHead className="text-gray-800 font-bold py-4 px-6">
+            Deuda Restante
+          </TableHead>
+          <TableHead className="text-gray-800 font-bold py-4 px-6">
+            Tipo de Prestamo
+          </TableHead>
+          <TableHead className="text-gray-800 font-bold py-4 px-6">
+            Ruta
+          </TableHead>
+          <TableHead className="text-gray-800 font-bold py-4 px-6">
+            Estado
+          </TableHead>
+          <TableHead className="text-gray-800 font-bold py-4 px-6"></TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {loans.map((loan) => (
+          <TableRow key={loan.id} className="border-b">
+            <TableCell className="py-4 px-6 font-semibold">
+              {loan.client_name}
+            </TableCell>
+            <TableCell className="py-4 px-6">{loan.dni}</TableCell>
+            <TableCell className="py-4 px-6">
+              {formatPrice(Number(loan.amount))}
+            </TableCell>
+            <TableCell className="py-4 px-6">
+              {formatPrice(Number(loan.remaining_debt))}
+            </TableCell>
+            <TableCell className="py-4 px-6">
+              {formatFrequency(loan.frequency)}
+            </TableCell>
+            <TableCell className="py-4 px-6">{loan.route}</TableCell>
+            <TableCell
+              className={`py-4 px-6 font-bold ${
+                loan.status === 'paid'
+                  ? 'text-green-600'
+                  : loan.status === 'pending'
+                  ? 'text-gray-600'
+                  : loan.status === 'active'
+                  ? 'text-blue-600'
+                  : 'text-gray-900'
+              }`}
+            >
+              {formatLoanStatus(loan.status)}
+            </TableCell>
+
+            <TableCell className="py-4 px-6">
+              <Actions loan={loan} />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          {/* Puedes agregar un resumen aquí si lo necesitas */}
+        </TableRow>
+      </TableFooter>
+    </Table>
+  )
+}

--- a/src/pages/loan/index.tsx
+++ b/src/pages/loan/index.tsx
@@ -1,48 +1,33 @@
-import {
-  Table,
-  TableBody,
-  TableCaption,
-  TableCell,
-  TableFooter,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
-import { ILoanTable } from "@/types/loans";
-import { Actions } from "./components/actions";
-import { formatPrice } from "@/utils/price-format";
-import { Button } from "@/components/ui/button";
-import { Link } from "react-router-dom";
-import { Input } from "@/components/ui/input";
-import { Search } from "lucide-react";
-import useForm from "@/hooks/useForm";
-import { FilterRoute } from "@/components/filterTables/filterRoute";
-import { useEffect, useState } from "react";
-import { formatFrequency } from "@/utils/format-frequency";
-import { FilterFrequency } from "@/components/filterTables/filterFrequency";
-import { getPaginationLoans } from "@/services/loan";
-import { IPaginationResponse } from "@/utils/fetch-data";
-import { formatLoanStatus } from "@/utils/format-loanState";
+import { FilterFrequency } from '@/components/filterTables/filterFrequency'
+import { FilterRoute } from '@/components/filterTables/filterRoute'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useLoanFilters } from '@/hooks/use-loan-filters'
+import { getPaginationLoans } from '@/services/loan'
+import { ILoanTable } from '@/types/loans'
+import { IPaginationResponse } from '@/utils/fetch-data'
+import { Search } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { LoansTable } from './components/loans-table'
 
 export default function LoanPage() {
-  const { formValues: search, handleInputChange } = useForm({
-    search_dni: ''
-  })
-  const [routeFilter, setRouteFilter] = useState<string>('')
-  const [frequencyFilter, setFrequencyFilter] = useState<string>('')
   const [loans, setLoans] = useState<ILoanTable[]>([])
-
-  const handleSetRouteFilter = (route: string) => setRouteFilter(route)
-  const handleSetFrequency = (route: string) => setRouteFilter(route)
+  const {
+    filteredLoans,
+    dniQuery,
+    searchByDni,
+    filterByFrequency,
+    filterByRoute,
+  } = useLoanFilters({ loans })
 
   useEffect(() => {
-    getPaginationLoans({ page: 1, limit: 20, filter: '' })
-      .then((response) => {
-        if (response.success) {
-          const { data, total_data, total_page, page, limit } = response.data as IPaginationResponse
-          setLoans(data as any)
-        }
-      })
+    getPaginationLoans({ page: 1, limit: 20, filter: '' }).then((response) => {
+      if (response.success) {
+        const { data } = response.data as IPaginationResponse<ILoanTable[]>
+        setLoans(data ?? [])
+      }
+    })
   }, [])
 
   return (
@@ -54,63 +39,29 @@ export default function LoanPage() {
 
         <div className="flex flex-col md:flex-row justify-between gap-4 w-full md:w-auto">
           <div className="relative w-full md:w-[350px]">
-            <Search className="text-gray-500 absolute top-2 left-2" width={19} />
+            <Search
+              className="text-gray-500 absolute top-0 bottom-0 my-auto left-3"
+              width={19}
+            />
             <Input
-              placeholder="Cédula del loane..."
+              placeholder="Cédula del cliente..."
               className="pl-10 w-full"
               name="search_dni"
-              onChange={handleInputChange}
-              value={search.search_dni}
+              onChange={(e) => searchByDni(e.target.value)}
+              value={dniQuery}
             />
           </div>
 
           <div className="mt-2 md:mt-0 flex gap-2">
-            <FilterFrequency handleSetFrequency={handleSetFrequency} />
-            <FilterRoute handleSetRouteFilter={handleSetRouteFilter} />
+            <FilterFrequency onChangeFrequency={filterByFrequency} />
+            <FilterRoute handleSetRouteFilter={filterByRoute} />
           </div>
         </div>
       </div>
 
       <div className="overflow-x-auto mt-6">
-        <Table className="w-full">
-          <TableCaption>Lista de loanes</TableCaption>
-          <TableHeader className="bg-gray-100">
-            <TableRow>
-              <TableHead className="text-gray-800 font-bold py-4 px-6">Nombre del cliente</TableHead>
-              <TableHead className="text-gray-800 font-bold py-4 px-6">Cédula</TableHead>
-              <TableHead className="text-gray-800 font-bold py-4 px-6">Monto solicitado</TableHead>
-              <TableHead className="text-gray-800 font-bold py-4 px-6">Deuda Restante</TableHead>
-              <TableHead className="text-gray-800 font-bold py-4 px-6">Tipo de Prestamo</TableHead>
-              <TableHead className="text-gray-800 font-bold py-4 px-6">Ruta</TableHead>
-              <TableHead className="text-gray-800 font-bold py-4 px-6">Estado</TableHead>
-              <TableHead className="text-gray-800 font-bold py-4 px-6"></TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {loans.map((loan) => (
-              <TableRow key={loan.id} className="border-b">
-                <TableCell className="py-4 px-6 font-semibold">{loan.client_name}</TableCell>
-                <TableCell className="py-4 px-6">{loan.dni}</TableCell>
-                <TableCell className="py-4 px-6">{formatPrice(Number(loan.amount))}</TableCell>
-                <TableCell className="py-4 px-6">{formatPrice(Number(loan.remaining_debt))}</TableCell>
-                <TableCell className="py-4 px-6">{formatFrequency(loan.frequency)}</TableCell>
-                <TableCell className="py-4 px-6">{loan.route}</TableCell>
-                <TableCell className={`py-4 px-6 font-bold ${loan.status === 'paid' ? 'text-green-600' : loan.status === 'pending' ? 'text-gray-600' : loan.status === 'active' ? 'text-blue-600' : 'text-gray-900'
-                  }`}>{formatLoanStatus(loan.status)}</TableCell>
-
-                <TableCell className="py-4 px-6">
-                  <Actions loan={loan} />
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-          <TableFooter>
-            <TableRow>
-              {/* Puedes agregar un resumen aquí si lo necesitas */}
-            </TableRow>
-          </TableFooter>
-        </Table>
+        <LoansTable loans={filteredLoans} />
       </div>
     </div>
-  );
+  )
 }

--- a/src/utils/contants.ts
+++ b/src/utils/contants.ts
@@ -1,0 +1,17 @@
+import { LoanFrequency } from '@/hooks/use-loan-filters'
+
+export const frequencies: LoanFrequency[] = [
+  'daily',
+  'weekly',
+  'biweekly',
+  'monthly',
+  'yearly',
+]
+
+export const frequencyMap: Record<LoanFrequency, string> = {
+  daily: 'Diario',
+  weekly: 'Semanal',
+  biweekly: 'Quincenal',
+  monthly: 'Mensual',
+  yearly: 'Anual',
+}


### PR DESCRIPTION
Se añade la lógica para filtrar por:
- Cédula del cliente.
- Frecuencia o tipo de préstamo.
- Ruta.

Se agregó el hook `useLoanFilters` el cual maneja la lógica del filtrado de los préstamos.
Se creó un nuevo componente para el renderizado de la tabla de préstamos.
Se añadió el componente `<Select />` de shadcn para filtrar la frecuencia.