### PR TITLE
Feat/loans table pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-router-dom": "^6.27.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.3",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "use-debounce": "10.0.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.13)
+      use-debounce:
+        specifier: 10.0.4
+        version: 10.0.4(react@18.3.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.11.1
@@ -2010,6 +2013,12 @@ packages:
       '@types/react':
         optional: true
 
+  use-debounce@10.0.4:
+    resolution: {integrity: sha512-6Cf7Yr7Wk7Kdv77nnJMf6de4HuDE4dTxKij+RqE9rufDsI6zsbjyAxcH5y2ueJCQAnfgKbzXbZHYlkFwmBlWkw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      react: '*'
+
   use-sidecar@1.1.2:
     resolution: {integrity: sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==}
     engines: {node: '>=10'}
@@ -3864,6 +3873,10 @@ snapshots:
       tslib: 2.7.0
     optionalDependencies:
       '@types/react': 18.3.11
+
+  use-debounce@10.0.4(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   use-sidecar@1.1.2(@types/react@18.3.11)(react@18.3.1):
     dependencies:

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  DotsHorizontalIcon,
+} from '@radix-ui/react-icons'
+
+import { cn } from '@/lib/utils'
+import { ButtonProps, buttonVariants } from '@/components/ui/button'
+
+const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
+  <nav
+    role="navigation"
+    aria-label="pagination"
+    className={cn('mx-auto flex w-full justify-center', className)}
+    {...props}
+  />
+)
+Pagination.displayName = 'Pagination'
+
+const PaginationContent = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<'ul'>
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    className={cn('flex flex-row items-center gap-1', className)}
+    {...props}
+  />
+))
+PaginationContent.displayName = 'PaginationContent'
+
+const PaginationItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<'li'>
+>(({ className, ...props }, ref) => (
+  <li ref={ref} className={cn('', className)} {...props} />
+))
+PaginationItem.displayName = 'PaginationItem'
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<ButtonProps, 'size'> &
+  React.ComponentProps<'a'>
+
+const PaginationLink = ({
+  className,
+  isActive,
+  size = 'icon',
+  ...props
+}: PaginationLinkProps) => (
+  <a
+    aria-current={isActive ? 'page' : undefined}
+    className={cn(
+      buttonVariants({
+        variant: isActive ? 'outline' : 'ghost',
+        size,
+      }),
+      className,
+    )}
+    {...props}
+  />
+)
+PaginationLink.displayName = 'PaginationLink'
+
+const PaginationPrevious = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to previous page"
+    size="default"
+    className={cn('gap-1 pl-2.5', className)}
+    {...props}
+  >
+    <ChevronLeftIcon className="h-4 w-4" />
+    <span>Anterior</span>
+  </PaginationLink>
+)
+PaginationPrevious.displayName = 'PaginationPrevious'
+
+const PaginationNext = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to next page"
+    size="default"
+    className={cn('gap-1 pr-2.5', className)}
+    {...props}
+  >
+    <span>Siguiente</span>
+    <ChevronRightIcon className="h-4 w-4" />
+  </PaginationLink>
+)
+PaginationNext.displayName = 'PaginationNext'
+
+const PaginationEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) => (
+  <span
+    aria-hidden
+    className={cn('flex h-9 w-9 items-center justify-center', className)}
+    {...props}
+  >
+    <DotsHorizontalIcon className="h-4 w-4" />
+    <span className="sr-only">More pages</span>
+  </span>
+)
+PaginationEllipsis.displayName = 'PaginationEllipsis'
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}

--- a/src/pages/loan/components/actions.tsx
+++ b/src/pages/loan/components/actions.tsx
@@ -4,9 +4,9 @@ import {
   EllipsisVertical,
   History,
   X,
-} from "lucide-react"
+} from 'lucide-react'
 
-import { Button } from "@/components/ui/button"
+import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,11 +15,11 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import { ILoanTable } from '@/types/loans'
-import { Link } from "react-router-dom"
+} from '@/components/ui/dropdown-menu'
+import { ILoan } from '@/types/loans'
+import { Link } from 'react-router-dom'
 interface IProps {
-  loan: ILoanTable
+  loan: ILoan
 }
 
 export const Actions = ({ loan }: IProps) => {
@@ -48,7 +48,7 @@ export const Actions = ({ loan }: IProps) => {
           </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
-        <DropdownMenuItem className='text-red-500'>
+        <DropdownMenuItem className="text-red-500">
           <X className="mr-2 h-4 w-4" />
           <span>Cancelar Solicitud</span>
         </DropdownMenuItem>

--- a/src/pages/loan/components/loans-pagination.tsx
+++ b/src/pages/loan/components/loans-pagination.tsx
@@ -1,0 +1,60 @@
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination'
+
+interface LoansPaginationProps {
+  goToPage: (page: number) => void
+  currentPage: number
+  totalPages: number
+}
+
+export function LoansPagination({
+  goToPage,
+  currentPage,
+  totalPages,
+}: LoansPaginationProps) {
+  const pagesAsNumbers = Array.from({ length: totalPages }, (_, i) => i + 1)
+  const goToPreviousPage = () => goToPage(currentPage - 1)
+  const goToNextPage = () => goToPage(currentPage + 1)
+  const hasPreviousPage = currentPage > 1
+  const hasNextPage = currentPage < totalPages
+
+  return (
+    <Pagination>
+      <PaginationContent>
+        {hasPreviousPage && (
+          <PaginationItem>
+            <PaginationPrevious
+              className="hover:cursor-pointer"
+              onClick={goToPreviousPage}
+            />
+          </PaginationItem>
+        )}
+        {pagesAsNumbers.map((pageNumber) => (
+          <PaginationItem key={pageNumber}>
+            <PaginationLink
+              className="hover:cursor-pointer"
+              isActive={pageNumber === currentPage}
+              onClick={() => goToPage(pageNumber)}
+            >
+              {pageNumber}
+            </PaginationLink>
+          </PaginationItem>
+        ))}
+        {hasNextPage && (
+          <PaginationItem>
+            <PaginationNext
+              onClick={goToNextPage}
+              className="hover:cursor-pointer"
+            />
+          </PaginationItem>
+        )}
+      </PaginationContent>
+    </Pagination>
+  )
+}

--- a/src/pages/loan/components/loans-table.tsx
+++ b/src/pages/loan/components/loans-table.tsx
@@ -1,3 +1,4 @@
+import { SkeletonTableRows } from '@/components/skeleton-table-rows'
 import {
   Table,
   TableBody,
@@ -8,15 +9,14 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { ILoanTable } from '@/types/loans'
+import { ILoan } from '@/types/loans'
 import { formatFrequency } from '@/utils/format-frequency'
 import { formatLoanStatus } from '@/utils/format-loanState'
 import { formatPrice } from '@/utils/price-format'
 import { Actions } from './actions'
-import { SkeletonTableRows } from '@/components/skeleton-table-rows'
 
 interface ILoanTableProps {
-  loans: ILoanTable[]
+  loans: ILoan[]
   isLoading: boolean
   error: Error | null
 }
@@ -32,6 +32,9 @@ export function LoansTable({ loans, isLoading, error }: ILoanTableProps) {
           </TableHead>
           <TableHead className="font-semibold text-gray-800 py-4 px-6">
             Cédula
+          </TableHead>
+          <TableHead className="font-semibold text-gray-800 py-4 px-6">
+            Fecha de préstamo
           </TableHead>
           <TableHead className="font-semibold text-gray-800 py-4 px-6">
             Monto solicitado
@@ -73,24 +76,29 @@ export function LoansTable({ loans, isLoading, error }: ILoanTableProps) {
             </TableCell>
           </TableRow>
         )}
-        {isLoading && <SkeletonTableRows columns={8} rows={4} />}
+        {isLoading && <SkeletonTableRows columns={8} rows={5} />}
         {!isLoading &&
           loans.map((loan) => (
             <TableRow key={loan.id} className="border-b">
               <TableCell className="py-4 px-6 font-semibold">
-                {loan.client_name}
+                {loan.client.name}
               </TableCell>
-              <TableCell className="py-4 px-6">{loan.dni}</TableCell>
+              <TableCell className="py-4 px-6">{loan.client.dni}</TableCell>
+              <TableCell className="py-4 px-6">
+                {new Date(loan.created_at).toDateString()}
+              </TableCell>
               <TableCell className="py-4 px-6">
                 {formatPrice(Number(loan.amount))}
               </TableCell>
               <TableCell className="py-4 px-6">
-                {formatPrice(Number(loan.remaining_debt))}
+                {formatPrice(Number(loan.total_pending))}
               </TableCell>
               <TableCell className="py-4 px-6">
-                {formatFrequency(loan.frequency)}
+                {formatFrequency(loan.payment_plan.frequency)}
               </TableCell>
-              <TableCell className="py-4 px-6">{loan.route}</TableCell>
+              <TableCell className="py-4 px-6">
+                {loan.client.route?.name ?? ''}
+              </TableCell>
               <TableCell
                 className={`py-4 px-6 font-bold ${
                   loan.status === 'paid'

--- a/src/pages/loan/hooks/use-loan-filters.ts
+++ b/src/pages/loan/hooks/use-loan-filters.ts
@@ -1,4 +1,4 @@
-import { ILoanTable } from '@/types/loans'
+import { ILoan } from '@/types/loans'
 import { useState } from 'react'
 
 export type LoanFrequency =
@@ -16,7 +16,7 @@ export type LoanFilters = {
 
 export type LoanFrequencyWithAll = LoanFrequency | 'all'
 
-export function useLoanFilters({ loans }: { loans: ILoanTable[] }) {
+export function useLoanFilters({ loans }: { loans: ILoan[] }) {
   const [dniQuery, setDniQuery] = useState('')
   const [frequencyFilter, setFrequencyFilter] =
     useState<LoanFrequencyWithAll>('all')
@@ -24,10 +24,13 @@ export function useLoanFilters({ loans }: { loans: ILoanTable[] }) {
 
   const filteredLoans = loans.filter((loan) => {
     const dniMatch =
-      loan.dni.toLowerCase().includes(dniQuery.toLowerCase()) || dniQuery === ''
+      loan.client.dni.toLowerCase().includes(dniQuery.toLowerCase()) ||
+      dniQuery === ''
     const frequencyMatch =
-      loan.frequency === frequencyFilter || frequencyFilter === 'all'
-    const routeMatch = loan.route === routeFilter || routeFilter === ''
+      loan.payment_plan.frequency === frequencyFilter ||
+      frequencyFilter === 'all'
+    const routeMatch =
+      loan.client.route?.name === routeFilter || routeFilter === ''
 
     return dniMatch && frequencyMatch && routeMatch
   })

--- a/src/pages/loan/hooks/use-loans.ts
+++ b/src/pages/loan/hooks/use-loans.ts
@@ -1,24 +1,61 @@
 import { getPaginationLoans } from '@/services/loan'
-import { ILoanTable } from '@/types/loans'
+import { ILoan } from '@/types/loans'
 import { IPaginationResponse } from '@/utils/fetch-data'
-import { useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useDebouncedCallback } from 'use-debounce'
 
-export function useLoans() {
+export function useLoans({ limit = 10 } = {}) {
+  const [loading, setLoading] = useState(false) // This is state is used to show loading status instantly when user search by dni
+  const [currentPage, setCurrentPage] = useState(1)
+  const [dni, setDni] = useState('')
+
   const { data, isError, error, isFetching } = useQuery({
-    queryKey: ['loans'],
+    queryKey: ['loans', currentPage, dni],
     queryFn: async () => {
       const response = await getPaginationLoans({
-        page: 1,
-        limit: 20,
-        filter: '',
+        page: currentPage,
+        limit,
+        filter: dni,
       })
       if (!response.success) {
         throw new Error(response.message)
       }
-      const data = response.data as IPaginationResponse<ILoanTable[]>
-      return data.data ?? []
+      const data = response.data as IPaginationResponse<ILoan[]>
+      return data
     },
+    placeholderData: keepPreviousData,
   })
 
-  return { data, isError, error, isLoading: isFetching }
+  const loans = data?.data ?? []
+  const totalLoans = data?.total_data ?? 0
+  const totalPages = data?.total_page ?? 0
+
+  const goToPage = (page: number) => {
+    setCurrentPage(page)
+  }
+
+  const searchByDni = useDebouncedCallback((dni: string) => {
+    setDni(dni)
+    setLoading(false)
+  }, 500)
+
+  const handleSearchByDni = (dni: string) => {
+    setLoading(true)
+    searchByDni(dni)
+  }
+
+  const isLoading = isFetching || loading
+
+  return {
+    isError,
+    error,
+    isLoading,
+    currentPage,
+    loans,
+    totalLoans,
+    totalPages,
+    searchByDni: handleSearchByDni,
+    goToPage,
+  }
 }

--- a/src/pages/loan/index.tsx
+++ b/src/pages/loan/index.tsx
@@ -7,16 +7,22 @@ import { Search } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { LoansTable } from './components/loans-table'
 import { useLoans } from './hooks/use-loans'
+import { LoansPagination } from './components/loans-pagination'
 
 export default function LoanPage() {
-  const { data: loans = [], isLoading, error } = useLoans()
   const {
-    filteredLoans,
-    dniQuery,
+    loans,
+    isLoading,
+    error,
+    currentPage,
+    totalPages,
+    goToPage,
     searchByDni,
-    filterByFrequency,
-    filterByRoute,
-  } = useLoanFilters({ loans })
+    totalLoans,
+  } = useLoans({ limit: 5 })
+  const { filteredLoans, filterByFrequency, filterByRoute } = useLoanFilters({
+    loans,
+  })
 
   return (
     <div className="flex flex-col gap-8 p-4 md:p-6 lg:p-8">
@@ -24,7 +30,6 @@ export default function LoanPage() {
         <Link to={'/loans/create'}>
           <Button className="w-full md:w-auto">Nuevo Prestamo</Button>
         </Link>
-
         <div className="flex flex-col md:flex-row justify-between gap-4 w-full md:w-auto">
           <div className="relative w-full md:w-[350px]">
             <Search
@@ -36,7 +41,6 @@ export default function LoanPage() {
               className="pl-10 w-full"
               name="search_dni"
               onChange={(e) => searchByDni(e.target.value)}
-              value={dniQuery}
             />
           </div>
           <div className="mt-2 md:mt-0 flex gap-2">
@@ -46,8 +50,24 @@ export default function LoanPage() {
         </div>
       </div>
 
-      <div className="mt-6">
+      <div>
+        <div className="mb-2">
+          <span className="text-sm text-muted-foreground">
+            Mostrando {loans.length} de {totalLoans} préstamos.
+          </span>
+        </div>
         <LoansTable isLoading={isLoading} loans={filteredLoans} error={error} />
+      </div>
+      <div className="flex justify-end">
+        <div>
+          {!isLoading && error == null && totalPages > 0 && (
+            <LoansPagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              goToPage={goToPage}
+            />
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/services/loan.ts
+++ b/src/services/loan.ts
@@ -18,7 +18,7 @@ export const getPaginationLoans = async ({
   limit,
 }: IPagination): Promise<IHandleResponse> => {
   return await fetchData({
-    url: `/loan/${page}/${limit}/${filter}`,
+    url: `/loan/full/${page}/${limit}/${filter}`,
     method: 'GET',
     useToken: true,
   })


### PR DESCRIPTION
Se añaden las siguientes mejoras a la página de préstamos:

- La búsqueda de préstamos por cédula pasa a realizarse desde el backend.
- Se añade la paginación de la tabla préstamos.
- Se utiliza el nuevo endpoint **/loan/full** el cuál devuelve los préstamos con los datos del cliente y plan de pago y permite la paginación y filtrado por cédula.