### PR TITLE
feat: implement requests management with filtering and API integration

### DIFF
--- a/src/pages/loan/components/actions.tsx
+++ b/src/pages/loan/components/actions.tsx
@@ -3,7 +3,6 @@ import {
   ClockArrowUp,
   EllipsisVertical,
   History,
-  X,
 } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
@@ -62,16 +61,6 @@ export const Actions = ({ loan }: IProps) => {
             </Link>
           </DropdownMenuItem>
         </DropdownMenuGroup>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem asChild>
-          <Button
-            className="w-full gap-2 justify-start text-red-500 hover:!text-red-500 hover:cursor-pointer"
-            variant="ghost"
-          >
-            <X className="h-4 w-4" />
-            <span>Cancelar solicitud</span>
-          </Button>
-        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/pages/loan/components/loan-status-filter.tsx
+++ b/src/pages/loan/components/loan-status-filter.tsx
@@ -27,6 +27,8 @@ export function LoanStatusFilter({ onChangeStatus }: StatusFilterProps) {
     onChangeStatus(newValue as LoanStatus)
   }
 
+  const allowedStatuses = loanStatus.filter((status) => status !== 'pending')
+
   return (
     <Select value={value} onValueChange={handleValueChange}>
       <SelectTrigger className="min-w-[180px]">
@@ -37,7 +39,7 @@ export function LoanStatusFilter({ onChangeStatus }: StatusFilterProps) {
           <SelectItem className="opacity-80" value="default">
             Todos
           </SelectItem>
-          {loanStatus.map((status) => (
+          {allowedStatuses.map((status) => (
             <SelectItem key={status} value={status}>
               {statusMap[status]}
             </SelectItem>

--- a/src/pages/requests/hooks/use-requests.ts
+++ b/src/pages/requests/hooks/use-requests.ts
@@ -1,0 +1,76 @@
+import { getRequests } from '@/services/loan'
+import { LoanStatus } from '@/types/loans'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { useDebouncedCallback } from 'use-debounce'
+
+export function useRequests({ limit = 10 } = {}) {
+  const [loading, setLoading] = useState(false) // This is state is used to show loading status instantly when user search by dni
+  const [currentPage, setCurrentPage] = useState(1)
+  const [dni, setDni] = useState('')
+  const [loanStatus, setLoanStatus] = useState<LoanStatus | undefined>()
+  const [route, setRoute] = useState<string | undefined>()
+  const { data, isError, error, isFetching } = useQuery({
+    queryKey: ['requests', currentPage, dni, loanStatus, route],
+    queryFn: async () => {
+      return await getRequests({
+        page: currentPage,
+        limit,
+        dni,
+        status: loanStatus,
+        route,
+      })
+    },
+    placeholderData: keepPreviousData,
+  })
+
+  const requests = data?.data ?? []
+  const totalRequests = data?.total_data ?? 0
+  const totalPages = data?.total_page ?? 0
+
+  const goToPage = (page: number) => {
+    setCurrentPage(page)
+  }
+
+  const searchByDni = useDebouncedCallback((dni: string) => {
+    setDni(dni)
+    setLoading(false)
+  }, 500)
+
+  const handleSearchByDni = (dni: string) => {
+    setLoading(true)
+    searchByDni(dni)
+  }
+
+  const filterByStatus = (status: LoanStatus | undefined) => {
+    setLoanStatus(status)
+    setCurrentPage(1)
+  }
+
+  const filterByRoute = (route: string | undefined) => {
+    setRoute(route)
+    setCurrentPage(1)
+  }
+
+  const resetFilters = () => {
+    setLoanStatus(undefined)
+    setRoute(undefined)
+  }
+
+  const isLoading = isFetching || loading
+
+  return {
+    isError,
+    error,
+    isLoading,
+    currentPage,
+    requests,
+    totalRequests,
+    totalPages,
+    filterByStatus,
+    filterByRoute,
+    searchByDni: handleSearchByDni,
+    goToPage,
+    resetFilters,
+  }
+}

--- a/src/pages/requests/pages/index.tsx
+++ b/src/pages/requests/pages/index.tsx
@@ -1,10 +1,9 @@
 import { LoansTable } from '@/pages/loan/components/loans-table'
-import { useLoans } from '@/pages/loan/hooks/use-loans'
 import { RequestsActions } from '../components/requests-actions'
+import { useRequests } from '../hooks/use-requests'
 
 export function RequestsPage() {
-  const { loans, error, isLoading } = useLoans()
-  const requests = loans.filter((loan) => loan.status === 'pending')
+  const { requests, error, isLoading } = useRequests()
 
   return (
     <div>

--- a/src/services/loan.ts
+++ b/src/services/loan.ts
@@ -72,6 +72,37 @@ export async function getLoans({
   return data
 }
 
+export async function getRequests({
+  page,
+  limit,
+  dni = '',
+  frequency,
+  route,
+}: IGetLoans) {
+  const token = Cookies.get('token')
+  const url = new URL(import.meta.env.VITE_BASE_URL)
+  url.pathname += `/loan/requests/${page}/${limit}/${dni}`
+  if (frequency) url.searchParams.append('frequency', frequency)
+  if (route) url.searchParams.append('route', route)
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+  if (!response.ok) {
+    throw new Error('Error al obtener los préstamos')
+  }
+
+  const { success, data, message } = (await response.json()) as IHandleResponse<
+    IPaginationResponse<ILoan[]>
+  >
+  if (!success) {
+    throw new Error(message)
+  }
+  return data
+}
+
 export const getLoanById = async (
   id: number,
 ): Promise<IHandleResponse<ILoan>> => {

--- a/src/utils/contants.ts
+++ b/src/utils/contants.ts
@@ -1,5 +1,5 @@
 import { LoanFrequency } from '@/pages/loan/hooks/use-loan-filters'
-import { PaymentStatus } from '@/types/loans'
+import { LoanStatus, PaymentStatus } from '@/types/loans'
 
 export const frequencies: LoanFrequency[] = [
   'daily',
@@ -17,12 +17,18 @@ export const frequencyMap: Record<LoanFrequency, string> = {
   yearly: 'Anual',
 }
 
-export const loanStatus = ['active', 'pending', 'paid'] as const
+export const loanStatus: LoanStatus[] = [
+  'active',
+  'pending',
+  'paid',
+  'rejected',
+] as const
 
-export const statusMap: Record<string, string> = {
+export const statusMap: Record<LoanStatus, string> = {
   active: 'Activo',
   pending: 'Pendiente',
   paid: 'Pagado',
+  rejected: 'Rechazado',
 }
 
 export const paymentStatusMap: Record<PaymentStatus, string> = {


### PR DESCRIPTION
En esta PR se añade la división entre préstamos y solicitudes, usando el nuevo endpoint `/loan/requests`